### PR TITLE
Expose DOMParser to WorkerGlobalScope

### DIFF
--- a/third_party/blink/renderer/core/xml/dom_parser.idl
+++ b/third_party/blink/renderer/core/xml/dom_parser.idl
@@ -30,7 +30,7 @@ enum SupportedType {
 [
     Constructor,
     ConstructorCallWith=Document,
-    Exposed=Window
+    Exposed=(Window,Worker)
 ] interface DOMParser {
     [NewObject, RaisesException] Document parseFromString(HTMLString str, SupportedType type);
 };


### PR DESCRIPTION
This CL exposes DOMParser to WorkerGlobalScope.

After this CL, WorkerGlobalScope can access DOMParser interface, but it's still not constructable ("new DOMParser()" crashes).